### PR TITLE
Add cross-compilation support

### DIFF
--- a/Communications/Makefile
+++ b/Communications/Makefile
@@ -1,17 +1,15 @@
 -include autogen.mk
 include ../common.mk
 
-LIB = libOrionComm.a
+LIB = $(TARGET)/libOrionComm.a
 OBJ = $(SRC:%.c=$(OBJ_DIR)/%.o)
 
 $(OBJ_DIR)/%.o:%.c
-	$(V)mkdir -p $(OBJ_DIR)
 	$(V)$(CC) -c $(CFLAGS) $< -o $@ -I../Utils -I../Communications $(QOUT)
 
 build: autogen.mk $(LIB)
 $(LIB): $(OBJ)
-	$(V)mkdir -p $(OUT_DIR)
-	$(V)$(AR) rcs $(OUT_DIR)/$(LIB) $(OBJ)
+	$(V)$(AR) rcs $(LIB) $(OBJ)
 
 # Generate code and populate autogen.mk file with src list
 autogen.mk: OrionPublicProtocol.xml
@@ -20,6 +18,5 @@ autogen.mk: OrionPublicProtocol.xml
 
 clean:
 	$(V)mkdir .save && mv OrionComm*.[ch] .save
-	$(V)rm -f $(LIB) *.[cho] *.html *.markdown *.css autogen.mk
-	$(V)rm -rf build/
+	$(V)rm -rf $(TARGET) *.[cho] *.html *.markdown *.css autogen.mk
 	$(V)mv .save/* . && rm -rf .save

--- a/Communications/Makefile
+++ b/Communications/Makefile
@@ -1,25 +1,25 @@
 -include autogen.mk
+include ../common.mk
 
 LIB = libOrionComm.a
-OBJ = $(SRC:.c=.o)
+OBJ = $(SRC:%.c=$(OBJ_DIR)/%.o)
 
-ifneq ($(VERBOSE), 1)
-    V=@
-endif
-
-%.o:%.c
+$(OBJ_DIR)/%.o:%.c
+	$(V)mkdir -p $(OBJ_DIR)
 	$(V)$(CC) -c $(CFLAGS) $< -o $@ -I../Utils -I../Communications $(QOUT)
 
 build: autogen.mk $(LIB)
 $(LIB): $(OBJ)
-	$(V)$(AR) rcs $(LIB) $(OBJ)
+	$(V)mkdir -p $(OUT_DIR)
+	$(V)$(AR) rcs $(OUT_DIR)/$(LIB) $(OBJ)
 
 # Generate code and populate autogen.mk file with src list
-autogen.mk: OrionPublicProtocol.xml 
+autogen.mk: OrionPublicProtocol.xml
 	@../GenerateOrionPublicPacket.sh || true
 	@echo "SRC = `echo *.c`" > autogen.mk
 
 clean:
 	$(V)mkdir .save && mv OrionComm*.[ch] .save
 	$(V)rm -f $(LIB) *.[cho] *.html *.markdown *.css autogen.mk
+	$(V)rm -rf build/
 	$(V)mv .save/* . && rm -rf .save

--- a/Examples/Examples.mk
+++ b/Examples/Examples.mk
@@ -2,25 +2,23 @@ include ../../common.mk
 
 .PHONY: build install clean
 
-BIN				= $(shell basename `pwd`)
+BIN				= $(TARGET)/$(shell basename `pwd`)
 SRCS			= $(wildcard *.c)
 OBJS			= $(SRCS:%.c=$(OBJ_DIR)/%.o)
 
 CFLAGS += $(EXTRA_CFLAGS) -I../../Communications -I../../Utils
 
 $(OBJ_DIR)/%.o:%.c
-	$(V)mkdir -p $(OBJ_DIR)
 	$(V)$(CC) -c -Wall $(CFLAGS) $< -o $@ $(QOUT)
 
-$(BIN): ../../Communications/libOrionComm.a ../../Utils/libOrionUtils.a $(OBJS)
-	$(V)$(CC) -o $(OUT_DIR)/$(BIN) $(OBJS) -L../../Communications/$(OUT_DIR) -L../../Utils/$(OUT_DIR) -lOrionComm -lOrionUtils -lm $(LDFLAGS) $(QOUT)
+$(BIN): ../../Communications/$(TARGET)/libOrionComm.a ../../Utils/$(TARGET)/libOrionUtils.a $(OBJS)
+	$(V)$(CC) -o $(BIN) $(OBJS) -L../../Communications/$(TARGET) -L../../Utils/$(TARGET) -lOrionComm -lOrionUtils -lm $(LDFLAGS) $(QOUT)
 
-../../Communications/libOrionComm.a:
+../../Communications/$(TARGET)/libOrionComm.a:
 	@make -C ../../Communications
 
-../../Utils/libOrionUtils.a:
+../../Utils/$(TARGET)/libOrionUtils.a:
 	@make -C ../../Utils
 
 clean:
-	$(V)rm -f $(BIN) *.debug *.o core *~
-	$(V)rm -rf build/
+	$(V)rm -rf $(TARGET) *.debug *.o core *~

--- a/Examples/Examples.mk
+++ b/Examples/Examples.mk
@@ -1,20 +1,19 @@
-ifneq ($(VERBOSE), 1)
-	V=@
-endif
+include ../../common.mk
 
 .PHONY: build install clean
 
 BIN				= $(shell basename `pwd`)
 SRCS			= $(wildcard *.c)
-OBJS			= $(SRCS:.c=.o)
+OBJS			= $(SRCS:%.c=$(OBJ_DIR)/%.o)
 
 CFLAGS += $(EXTRA_CFLAGS) -I../../Communications -I../../Utils
 
-%.o:%.c
+$(OBJ_DIR)/%.o:%.c
+	$(V)mkdir -p $(OBJ_DIR)
 	$(V)$(CC) -c -Wall $(CFLAGS) $< -o $@ $(QOUT)
 
 $(BIN): ../../Communications/libOrionComm.a ../../Utils/libOrionUtils.a $(OBJS)
-	$(V)$(CC) -o $(BIN) $(OBJS) -L../../Communications -L../../Utils -lOrionComm -lOrionUtils -lm $(LDFLAGS) $(QOUT)
+	$(V)$(CC) -o $(OUT_DIR)/$(BIN) $(OBJS) -L../../Communications/$(OUT_DIR) -L../../Utils/$(OUT_DIR) -lOrionComm -lOrionUtils -lm $(LDFLAGS) $(QOUT)
 
 ../../Communications/libOrionComm.a:
 	@make -C ../../Communications
@@ -22,5 +21,6 @@ $(BIN): ../../Communications/libOrionComm.a ../../Utils/libOrionUtils.a $(OBJS)
 ../../Utils/libOrionUtils.a:
 	@make -C ../../Utils
 
-clean: 
+clean:
 	$(V)rm -f $(BIN) *.debug *.o core *~
+	$(V)rm -rf build/

--- a/Utils/Makefile
+++ b/Utils/Makefile
@@ -1,19 +1,16 @@
 include ../common.mk
 
-LIB = libOrionUtils.a
+LIB = $(TARGET)/libOrionUtils.a
 SRC = $(wildcard *.c)
 OBJ = $(SRC:%.c=$(OBJ_DIR)/%.o)
 
 $(OBJ_DIR)/%.o:%.c
-	$(V)mkdir -p $(OBJ_DIR)
 	$(V)$(CC) -c $(CFLAGS) $< -o $@ $(QOUT) -I../Communications
 
 build: $(LIB)
 $(LIB): $(OBJ)
-	$(V)mkdir -p $(OUT_DIR)
-	$(V)$(AR) rcs $(OUT_DIR)/$(LIB) $(OBJ)
+	$(V)$(AR) rcs $(LIB) $(OBJ)
 	$(V)rm *.zip 2>/dev/null || true
 
 clean:
-	$(V)rm -f $(LIB) *.o
-	$(V)rm -rf build/
+	$(V)rm -rf $(TARGET)

--- a/Utils/Makefile
+++ b/Utils/Makefile
@@ -1,18 +1,19 @@
+include ../common.mk
+
 LIB = libOrionUtils.a
 SRC = $(wildcard *.c)
-OBJ = $(SRC:.c=.o)
+OBJ = $(SRC:%.c=$(OBJ_DIR)/%.o)
 
-ifneq ($(VERBOSE), 1)
-    V=@
-endif
-
-%.o:%.c
+$(OBJ_DIR)/%.o:%.c
+	$(V)mkdir -p $(OBJ_DIR)
 	$(V)$(CC) -c $(CFLAGS) $< -o $@ $(QOUT) -I../Communications
 
 build: $(LIB)
 $(LIB): $(OBJ)
-	$(V)$(AR) rcs $(LIB) $(OBJ)
+	$(V)mkdir -p $(OUT_DIR)
+	$(V)$(AR) rcs $(OUT_DIR)/$(LIB) $(OBJ)
 	$(V)rm *.zip 2>/dev/null || true
 
 clean:
 	$(V)rm -f $(LIB) *.o
+	$(V)rm -rf build/

--- a/common.mk
+++ b/common.mk
@@ -4,7 +4,9 @@ endif
 
 TARGET ?= x86
 
-ifeq ($(TARGET), arm)
+ifeq ($(TARGET), x86)
+	CFLAGS=-fPIC
+else ifeq ($(TARGET), arm)
 	PREFIX=arm-linux-gnueabi-
     CC=$(PREFIX)gcc
     AR=$(PREFIX)ar

--- a/common.mk
+++ b/common.mk
@@ -1,0 +1,18 @@
+ifneq ($(VERBOSE), 1)
+    V=@
+endif
+
+TARGET ?= x86
+
+ifeq ($(TARGET), arm)
+	PREFIX=arm-linux-gnueabi-
+    CC=$(PREFIX)gcc
+    AR=$(PREFIX)ar
+else ifeq ($(TARGET), tegra)
+	PREFIX=aarch64-unknown-linux-gnu-
+    CC=$(PREFIX)gcc
+    AR=$(PREFIX)ar
+endif
+
+OUT_DIR = build/$(TARGET)
+OBJ_DIR = $(OUT_DIR)/obj

--- a/common.mk
+++ b/common.mk
@@ -1,5 +1,5 @@
 ifneq ($(VERBOSE), 1)
-    V=@
+	V=@
 endif
 
 TARGET ?= x86
@@ -8,13 +8,12 @@ ifeq ($(TARGET), x86)
 	CFLAGS=-fPIC
 else ifeq ($(TARGET), arm)
 	PREFIX=arm-linux-gnueabi-
-    CC=$(PREFIX)gcc
-    AR=$(PREFIX)ar
 else ifeq ($(TARGET), tegra)
 	PREFIX=aarch64-unknown-linux-gnu-
-    CC=$(PREFIX)gcc
-    AR=$(PREFIX)ar
 endif
 
-OUT_DIR = build/$(TARGET)
-OBJ_DIR = $(OUT_DIR)/obj
+CC=$(PREFIX)gcc
+AR=$(PREFIX)ar
+OBJ_DIR = $(TARGET)/obj
+
+$(shell mkdir -p $(OBJ_DIR))


### PR DESCRIPTION
Factors out common components from the makefiles and adds support for multiple targets. New targets should be added to "common.mk". The required versions of gcc and ar must be available on the path.