### PR TITLE
Reset Comms Handle on close

### DIFF
--- a/Communications/OrionCommLinux.c
+++ b/Communications/OrionCommLinux.c
@@ -181,7 +181,7 @@ void OrionCommClose(void)
 {
     // Easy enough, just close the file descriptor
     close(Handle);
-
+    Handle = -1;
 }// OrionCommClose
 
 BOOL OrionCommSend(const OrionPkt_t *pPkt)


### PR DESCRIPTION
When network comms are used, the global comms variable Handle is not reset when comms are closed.  This results in comms always reporting as successfully connected for subsequence connection attempts, even if no valid connection is made and connection attempt times out.