### PR TITLE
Uniformity in whitespace

### DIFF
--- a/Communications/OrionPublicProtocol.xml
+++ b/Communications/OrionPublicProtocol.xml
@@ -94,7 +94,7 @@ See TrilliumPacket.c (in the Orion SDK) for details.
         <Value name="ORION_PKT_HITACHI_SETTINGS" comment="Hitachi-specific camera settings"/>
         <Value name="ORION_PKT_BAE_SETTINGS" comment="BAE-specific camera settings"/>
         <Value name="ORION_PKT_SONY_SETTINGS" comment="Sony-specific camera settings"/>
-		<Value name="ORION_PKT_KTNC_SETTINGS" comment="KTnC-specific camera settings"/>
+        <Value name="ORION_PKT_KTNC_SETTINGS" comment="KTnC-specific camera settings"/>
         <Value name="ORION_PKT_PRIVATE_70" value="0x70" comment="Reserved packet identifier" hidden="true"/>
         <Value name="ORION_PKT_PRIVATE_71" comment="Reserved packet identifier" hidden="true"/>
         <Value name="ORION_PKT_AUTOPILOT_DATA" value="0x80" comment="Autopilot state data, if available"/>


### PR DESCRIPTION
A line in the XML has tabs instead of spaces. Unless the editor uses 4-space tabs, this breaks visual indentation.